### PR TITLE
Update mdbook-katex

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -31,6 +31,6 @@ jobs:
         which mdbook || cargo install mdbook &&
         which mdbook-mermaid || cargo install mdbook-mermaid &&
         which mdbook-linkcheck || cargo install mdbook-linkcheck &&
-        which mdbook-katex || cargo install --git https://github.com/heliaxdev/mdbook-katex.git
+        which mdbook-katex || cargo install --git https://github.com/heliaxdev/mdbook-katex.git --rev 2b37a542808a0b3cc8e799851514e145990f1e3a
     - name: Generate website
       run: make build

--- a/.github/workflows/deploy-master.yml
+++ b/.github/workflows/deploy-master.yml
@@ -31,7 +31,7 @@ jobs:
         which mdbook || cargo install mdbook &&
         which mdbook-mermaid || cargo install mdbook-mermaid &&
         which mdbook-linkcheck || cargo install mdbook-linkcheck &&
-        which mdbook-katex || cargo install --git https://github.com/heliaxdev/mdbook-katex.git
+        which mdbook-katex || cargo install --git https://github.com/heliaxdev/mdbook-katex.git --rev 2b37a542808a0b3cc8e799851514e145990f1e3a
     - name: Generate website
       run: make build
     - name: Create tag folder

--- a/.github/workflows/deploy-tag.yml
+++ b/.github/workflows/deploy-tag.yml
@@ -31,7 +31,7 @@ jobs:
         which mdbook || cargo install mdbook &&
         which mdbook-mermaid || cargo install mdbook-mermaid &&
         which mdbook-linkcheck || cargo install mdbook-linkcheck &&
-        which mdbook-katex || cargo install --git https://github.com/heliaxdev/mdbook-katex.git
+        which mdbook-katex || cargo install --git https://github.com/heliaxdev/mdbook-katex.git --rev 2b37a542808a0b3cc8e799851514e145990f1e3a
     - name: Generate website
       run: make build
     - uses: olegtarasov/get-tag@v2.1

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,6 @@ dev-deps:
 	$(cargo) install mdbook
 	$(cargo) install mdbook-mermaid
 	$(cargo) install mdbook-linkcheck
-	$(cargo) install --git https://github.com/heliaxdev/mdbook-katex.git
+	$(cargo) install --git https://github.com/heliaxdev/mdbook-katex.git --rev 2b37a542808a0b3cc8e799851514e145990f1e3a
 
 .PHONY: build serve dev-deps


### PR DESCRIPTION
Fixes the version of mdbook-katex to a specific commit that relates to fixing https://github.com/anoma/specs/issues/91

It could be good practice to fix the versions explicitly in general (so we know for each version of our `specs` repo, what versions of the mdbook dependencies are used to definitively build it)