### PR TITLE
Update CI to build with new mdbook plugin versions

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -27,3 +27,8 @@ jobs:
       run: make dev-deps
     - name: Generate website
       run: make build
+    - name: Archive rendered site
+      uses: actions/upload-artifact@v3
+      with:
+        name: rendered-site
+        path: book/html/

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -24,10 +24,6 @@ jobs:
           ~/.cargo
         key: ${{ hashFiles('Makefile') }}
     - name: Install cargo deps
-      run: |
-        which mdbook || cargo install mdbook &&
-        which mdbook-mermaid || cargo install mdbook-mermaid &&
-        which mdbook-linkcheck || cargo install mdbook-linkcheck &&
-        which mdbook-katex || cargo install --git https://github.com/heliaxdev/mdbook-katex.git --rev 2b37a542808a0b3cc8e799851514e145990f1e3a
+      run: make dev-deps
     - name: Generate website
       run: make build

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -21,10 +21,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
+          ~/.cargo
         key: ${{ hashFiles('Makefile') }}
     - name: Install cargo deps
       run: |

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -25,7 +25,7 @@ jobs:
           ~/.cargo/registry/index/
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
-        key: ${{ runner.os }}-cargo-v1
+        key: ${{ hashFiles('Makefile') }}
     - name: Install cargo deps
       run: |
         which mdbook || cargo install mdbook &&

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,4 +1,4 @@
-name: Build and Deploy
+name: Build PR
 
 on:
   pull_request:
@@ -6,7 +6,7 @@ on:
       - master
 
 jobs:
-  build-deploy:
+  build:
     runs-on: ubuntu-20.04
 
     steps:

--- a/.github/workflows/deploy-master.yml
+++ b/.github/workflows/deploy-master.yml
@@ -1,4 +1,4 @@
-name: Build and Deploy
+name: Deploy Master
 
 on:
   push:

--- a/.github/workflows/deploy-master.yml
+++ b/.github/workflows/deploy-master.yml
@@ -21,10 +21,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
+          ~/.cargo
         key: ${{ hashFiles('Makefile') }}
     - name: Install cargo deps
       run: |

--- a/.github/workflows/deploy-master.yml
+++ b/.github/workflows/deploy-master.yml
@@ -24,11 +24,7 @@ jobs:
           ~/.cargo
         key: ${{ hashFiles('Makefile') }}
     - name: Install cargo deps
-      run: |
-        which mdbook || cargo install mdbook &&
-        which mdbook-mermaid || cargo install mdbook-mermaid &&
-        which mdbook-linkcheck || cargo install mdbook-linkcheck &&
-        which mdbook-katex || cargo install --git https://github.com/heliaxdev/mdbook-katex.git --rev 2b37a542808a0b3cc8e799851514e145990f1e3a
+      run: make dev-deps
     - name: Generate website
       run: make build
     - name: Create tag folder

--- a/.github/workflows/deploy-master.yml
+++ b/.github/workflows/deploy-master.yml
@@ -25,7 +25,7 @@ jobs:
           ~/.cargo/registry/index/
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
-        key: ${{ runner.os }}-cargo-v1
+        key: ${{ hashFiles('Makefile') }}
     - name: Install cargo deps
       run: |
         which mdbook || cargo install mdbook &&

--- a/.github/workflows/deploy-tag.yml
+++ b/.github/workflows/deploy-tag.yml
@@ -1,4 +1,4 @@
-name: Build and Deploy
+name: Deploy Tag
 
 on:
   push:

--- a/.github/workflows/deploy-tag.yml
+++ b/.github/workflows/deploy-tag.yml
@@ -24,11 +24,7 @@ jobs:
           ~/.cargo
         key: ${{ hashFiles('Makefile') }}
     - name: Install cargo deps
-      run: |
-        which mdbook || cargo install mdbook &&
-        which mdbook-mermaid || cargo install mdbook-mermaid &&
-        which mdbook-linkcheck || cargo install mdbook-linkcheck &&
-        which mdbook-katex || cargo install --git https://github.com/heliaxdev/mdbook-katex.git --rev 2b37a542808a0b3cc8e799851514e145990f1e3a
+      run: make dev-deps
     - name: Generate website
       run: make build
     - uses: olegtarasov/get-tag@v2.1

--- a/.github/workflows/deploy-tag.yml
+++ b/.github/workflows/deploy-tag.yml
@@ -21,10 +21,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
+          ~/.cargo
         key: ${{ hashFiles('Makefile') }}
     - name: Install cargo deps
       run: |

--- a/.github/workflows/deploy-tag.yml
+++ b/.github/workflows/deploy-tag.yml
@@ -25,7 +25,7 @@ jobs:
           ~/.cargo/registry/index/
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
-        key: ${{ runner.os }}-cargo-v1
+        key: ${{ hashFiles('Makefile') }}
     - name: Install cargo deps
       run: |
         which mdbook || cargo install mdbook &&


### PR DESCRIPTION
Reinstall mdbook and plugins every time the `Makefile` changes, which shouldn't be often but may happen when we change mdbook or dependencies

Couple other changes:
- rename some GitHub workflows/jobs
- publish the built `book/html/` folder for PR GitHub workflows so we can inspect them to see that things built as expected