### PR TITLE
Add some admen to conceptual-context 

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -47,4 +47,5 @@
   - [Randomness beacon](./anomanomics/randomness-beacon.md)
   - [Liquid RPGF](./anomanomics/liquid-rpgf.md)
   - [Schelling-human PPGF](./anomanomics/schelling-ppgf.md)
+- [Glossary](./glossary.md)
 - [Acknowledgements](./acknowledgements.md)

--- a/src/architecture/conceptual-context.md
+++ b/src/architecture/conceptual-context.md
@@ -9,7 +9,8 @@ _motivations_ of agents, but rather describes the state of the
 [system](../glossary.md#system) as a function of the decisions taken by agents
 over (partially ordered) time. 
 
-0. An Agent is ...
+0. *Agent* is a primary notion in the Anoma protocol that aims to extend/replace
+   the notion of _process_ in the distributed systems.
 
 1. _Agents_ are assumed to have the ability to:
    - generate local randomness, 
@@ -24,14 +25,9 @@ over (partially ordered) time.
 
 3. Agents can _join_ and _leave_ the world at any time.
 
-4. The world is message-passing transparent, meaning that any agent has access
-   to the list of messages sent and received by any other agent. 
-
-<!-- What kind of decisions an agent can make? -->
-5. Knowledge of all *actions* committed by agents are recorded in the *history.
+4. Knowledge of all *actions* committed by agents are recorded in the *history.
    The *state* of the system at any point in time is a function of the history
     of actions committed by agents up to that point in time.
-
 
 <!-- 
 We can use Juvix syntax instead of Haskell syntax for the following snippets. I'm commenting as I don't see they add much clarity to the spec, (at least not now)

--- a/src/architecture/conceptual-context.md
+++ b/src/architecture/conceptual-context.md
@@ -1,11 +1,9 @@
 # Conceptual context
 
-<!-- What if the title goes to the point directly, "Agents in a world" -->
-
 The Anoma architecture operates on the basis of
-*[agents](../glossary.md#agents)* in the real world. The architecture does not
-presume any sort of global view or global time. It also does not presume any
-particular _motivations_ of agents, but rather describes the state of the
+*[agents](../glossary.md#agents)*. The architecture does not presume any sort of
+global view or global time. It also does not presume any particular
+_motivations_ of agents, but rather describes the state of the
 [system](../glossary.md#system) as a function of the decisions taken by agents
 over (partially ordered) time. 
 
@@ -31,7 +29,8 @@ over (partially ordered) time.
     of actions committed by agents up to that point in time.
 
 <!-- 
-We can use Juvix syntax instead of Haskell syntax for the following snippets. I'm commenting as I don't see they add much clarity to the spec, (at least not now)
+We can use Juvix syntax instead of Haskell syntax for the following snippets. I'm commenting
+this out as I don't see they add much clarity to the spec, (at least not now)
 
 ```juvix
 

--- a/src/architecture/conceptual-context.md
+++ b/src/architecture/conceptual-context.md
@@ -2,17 +2,17 @@
 
 <!-- What if the title goes to the point directly, "Agents in a world" -->
 
-The Anoma architecture operates on the basis of *[agents](../glossary.md#agents)
-in a [world](../glossary.md#world)*. The architecture does not presume any sort
-of global view or global time. It also does not presume any particular
+The Anoma architecture operates on the basis of
+*[agents](../glossary.md#agents)*. The architecture does not presume any sort of
+global view or global time. It also does not presume any particular
 _motivations_ of agents, but rather describes the state of the
 [system](../glossary.md#system) as a function of the decisions taken by agents
 over (partially ordered) time. 
 
-0. *Agent* is a primary notion in the Anoma protocol that aims to extend/replace
+1. *Agent* is a primary notion in the Anoma protocol that aims to extend/replace
    the notion of _process_ in the distributed systems.
 
-1. _Agents_ are assumed to have the ability to:
+2. _Agents_ are assumed to have the ability to:
    - generate local randomness, 
    - locally store and retrieve data, 
    - perform arbitrary classical computations, 
@@ -23,7 +23,8 @@ over (partially ordered) time.
 2. Agents _may_ have local input (e.g. human user input) and/or local randomness
    (e.g. from a hardware random number generator).
 
-3. Agents can _join_ and _leave_ the world at any time.
+3. Agents can _join_ and _leave_ the [system](./../glossary.md#system) at any
+   time.
 
 4. Knowledge of all *actions* committed by agents are recorded in the *history.
    The *state* of the system at any point in time is a function of the history

--- a/src/architecture/conceptual-context.md
+++ b/src/architecture/conceptual-context.md
@@ -7,15 +7,19 @@ The Anoma architecture operates on the basis of *[agents](../glossary.md#agents)
 1. _Agents_ are assumed to have the ability to:
    - generate local randomness, 
    - locally store and retrieve data, 
-   - perform arbitrary classical (Turing-equivalent) computations, and
-   - send and receive messages over an arbitrary, asynchronous physical network.
+   - perform arbitrary classical computations, and
+   - send and receive [messages](../glossary.md#message) over an arbitrary, asynchronous physical network.
 
 2. Agents _may_ have local input (e.g. human user input) and/or local randomness (e.g. from a hardware random number generator).
 
-<!-- TODO: who is we exactly, the user, the system  -->
-The _world_ is open, in that agents can join and leave at any time -- from the architectural perspective, we can only speak of and reason about the perspective of a particular agent, i.e. which messages they have sent and received, and in what (local) order.
+3. Agents can _join_ and _leave_ the world at any time.
 
-The architecture does not presume any sort of global view or global time. It also does not presume any particular _motivations_ of agents, but rather describes the state of the system as a function of the decisions taken by agents over (partially ordered) time. Knowledge of all decisions taken by agents in a subset of history determines the state of that subset of the system at the point of conclusion of that history.
+4. The world is message-passing transparent, meaning that any agent has access to the list of messages sent and received by any other agent. 
+
+<!-- This paragraph is quite confusing to me. -->
+The architecture does not presume any sort of global view or global time. It also does not presume any particular _motivations_ of agents, but rather describes the state of the system as a function of the decisions taken by agents over (partially ordered) time. 
+<!-- I dont' understand this sentence, what's the main intention of it. -->
+Knowledge of all decisions taken by agents in a subset of history determines the state of that subset of the system at the point of conclusion of that history.
 
 > Note: The concept of _agent_ is similar to that of _process_ as used in the distributed systems literature. We use "agent" to emphasize non-determinism (local randomness and/or external user choice input) and possible agency (in the sense of decision-making which impacts the state of the system). The latter is especially important as causal accounting requires correspondence between the state of the system and state of the world, a correspondence which can only be maintained as a product of individual data inputs by agents which themselves correspond in local ways, as the protocol itself has no knowledge of the state of the world.
 

--- a/src/architecture/conceptual-context.md
+++ b/src/architecture/conceptual-context.md
@@ -3,14 +3,14 @@
 <!-- What if the title goes to the point directly, "Agents in a world" -->
 
 The Anoma architecture operates on the basis of
-*[agents](../glossary.md#agents)*. The architecture does not presume any sort of
-global view or global time. It also does not presume any particular
-_motivations_ of agents, but rather describes the state of the
+*[agents](../glossary.md#agents)* in the real world. The architecture does not
+presume any sort of global view or global time. It also does not presume any
+particular _motivations_ of agents, but rather describes the state of the
 [system](../glossary.md#system) as a function of the decisions taken by agents
 over (partially ordered) time. 
 
 1. *Agent* is a primary notion in the Anoma protocol that aims to extend/replace
-   the notion of _process_ in the distributed systems.
+   the notion of _process_ in the Distributed Systems literature.
 
 2. _Agents_ are assumed to have the ability to:
    - generate local randomness, 

--- a/src/architecture/conceptual-context.md
+++ b/src/architecture/conceptual-context.md
@@ -1,27 +1,42 @@
 # Conceptual context
 
-The Anoma architecture operates on the basis of *[agents](../glossary.md#agents) in a [world](../glossary.md#world)*. 
+<!-- What if the title goes to the point directly, "Agents in a world" -->
+
+The Anoma architecture operates on the basis of *[agents](../glossary.md#agents)
+in a [world](../glossary.md#world)*. The architecture does not presume any sort
+of global view or global time. It also does not presume any particular
+_motivations_ of agents, but rather describes the state of the
+[system](../glossary.md#system) as a function of the decisions taken by agents
+over (partially ordered) time. 
 
 0. An Agent is ...
 
 1. _Agents_ are assumed to have the ability to:
    - generate local randomness, 
    - locally store and retrieve data, 
-   - perform arbitrary classical computations, and
-   - send and receive [messages](../glossary.md#message) over an arbitrary, asynchronous physical network.
+   - perform arbitrary classical computations, 
+   - create, send, receive and read [messages](../glossary.md#message) over an
+     arbitrary, asynchronous physical network.
+   
 
-2. Agents _may_ have local input (e.g. human user input) and/or local randomness (e.g. from a hardware random number generator).
+2. Agents _may_ have local input (e.g. human user input) and/or local randomness
+   (e.g. from a hardware random number generator).
 
 3. Agents can _join_ and _leave_ the world at any time.
 
-4. The world is message-passing transparent, meaning that any agent has access to the list of messages sent and received by any other agent. 
+4. The world is message-passing transparent, meaning that any agent has access
+   to the list of messages sent and received by any other agent. 
 
-<!-- This paragraph is quite confusing to me. -->
-The architecture does not presume any sort of global view or global time. It also does not presume any particular _motivations_ of agents, but rather describes the state of the system as a function of the decisions taken by agents over (partially ordered) time. 
-<!-- I dont' understand this sentence, what's the main intention of it. -->
-Knowledge of all decisions taken by agents in a subset of history determines the state of that subset of the system at the point of conclusion of that history.
+<!-- What kind of decisions an agent can make? -->
+5. Knowledge of all *actions* committed by agents are recorded in the *history.
+   The *state* of the system at any point in time is a function of the history
+    of actions committed by agents up to that point in time.
 
-> Note: The concept of _agent_ is similar to that of _process_ as used in the distributed systems literature. We use "agent" to emphasize non-determinism (local randomness and/or external user choice input) and possible agency (in the sense of decision-making which impacts the state of the system). The latter is especially important as causal accounting requires correspondence between the state of the system and state of the world, a correspondence which can only be maintained as a product of individual data inputs by agents which themselves correspond in local ways, as the protocol itself has no knowledge of the state of the world.
+
+<!-- 
+We can use Juvix syntax instead of Haskell syntax for the following snippets. I'm commenting as I don't see they add much clarity to the spec, (at least not now)
+
+```juvix
 
 ```haskell
 type Agent
@@ -33,8 +48,14 @@ class Monad m => AgentContext m where
     get :: ByteString -> m (Maybe ByteString)
 ```
 
+ -->
+
 The rest of this specification defines the _Anoma protocol_, which is specific logic that agents run to read, create, and process messages. For convenience, the Anoma protocol shall be referred to henceforth as just _the protocol_.
 
-```
+<!-- 
+
+```haskell
 type Protocol
 ```
+
+ -->

--- a/src/architecture/conceptual-context.md
+++ b/src/architecture/conceptual-context.md
@@ -1,6 +1,19 @@
 # Conceptual context
 
-The Anoma architecture operates on the basis of _agents_ in a _world_. _Agents_ are assumed to have the ability to generate local randomness, locally store and retrieve data, perform arbitrary classical (Turing-equivalent) compute, and send and receive messages over an arbitrary, asynchronous physical network. Agents _may_ have local (e.g. human user) input. Agents operate in a _world_, which consists of other agents of the same (abstract) capacities, with whom they may be able to communicate. The _world_ is open, in that agents can join and leave at any time -- from the architectural perspective, we can only speak of and reason about the perspective of a particular agent, i.e. which messages they have sent and received, and in what (local) order.
+The Anoma architecture operates on the basis of *[agents](../glossary.md#agents) in a [world](../glossary.md#world)*. 
+
+0. An Agent is ...
+
+1. _Agents_ are assumed to have the ability to:
+   - generate local randomness, 
+   - locally store and retrieve data, 
+   - perform arbitrary classical (Turing-equivalent) computations, and
+   - send and receive messages over an arbitrary, asynchronous physical network.
+
+2. Agents _may_ have local input (e.g. human user input) and/or local randomness (e.g. from a hardware random number generator).
+
+<!-- TODO: who is we exactly, the user, the system  -->
+The _world_ is open, in that agents can join and leave at any time -- from the architectural perspective, we can only speak of and reason about the perspective of a particular agent, i.e. which messages they have sent and received, and in what (local) order.
 
 The architecture does not presume any sort of global view or global time. It also does not presume any particular _motivations_ of agents, but rather describes the state of the system as a function of the decisions taken by agents over (partially ordered) time. Knowledge of all decisions taken by agents in a subset of history determines the state of that subset of the system at the point of conclusion of that history.
 

--- a/src/architecture/prerequisite-primitives.md
+++ b/src/architecture/prerequisite-primitives.md
@@ -2,14 +2,21 @@
 
 ## Canonical compute representation
 
-The protocol requires a canonical serialisation of Turing-equivalent functions and data.
+The protocol requires a [canonical serialisation](../glossary.md#canonical-serialization) of [Turing-equivalent](../glossary.md#turing-complete) functions and data.
 
 ```haskell
 serialise :: a -> ByteString
 deserialise :: ByteString -> (Maybe a)
 ```
 
-_Canonical_ here means that this serialisation must be agreed to by all agents using the protocol, such that those agents agree on the results of computing `serialise (eval (deserialise f))` for an arbitrary `f`. Internal representations of compute may vary as long as this external equivalence holds. Certain additional correspondences of internal representations may be required for particular verifiable computation schemes (see below).
+<!-- 
+"by all agents using the protocol" 
+
+
+ -->
+_Canonical_ here means that this serialisation must be agreed to by all agents using the protocol, such that those agents agree on the results of computing `serialise (eval (deserialise f))` for an arbitrary `f`. 
+
+Internal representations of compute may vary as long as this external equivalence holds. Certain additional correspondences of internal representations may be required for particular verifiable computation schemes (see below).
 
 For the remainder of this specification, this canonical representation is taken as implicit, and may be assumed where appropriate (e.g. `serialise` is called before sending a function over the network).
 

--- a/src/architecture/prerequisite-primitives.md
+++ b/src/architecture/prerequisite-primitives.md
@@ -7,16 +7,14 @@ The protocol requires a [*canonical* serialisation](../glossary.md#canonical-ser
 A *serialisation* can be any function which maps data to a series of bytes. The inverse function which maps a series of bytes to data is referred to as a *deserialisation*.
 
 Being *canonical* for a serialisation $s$ means that there exists a function $d$
-such that, for any function or data $x$, all the agents using the protocol agree that
+such that, for any function or data $x$, all the agents using the protocol agree
+that the following equation holds.
 
 $$s(\mathsf{eval}(d(x))) = x.$
 
+In what follows, we assume any serialisation is canonical, unless otherwise specified. Internal representations of compute may vary as long as this external equivalence holds. Certain additional correspondences of internal representations may be required for particular verifiable computation schemes (see below).
 
-<!--  This is rather important I'd say.
-What if it's mention earlier.
- -->
-
-Internal representations of compute may vary as long as this external equivalence holds. Certain additional correspondences of internal representations may be required for particular verifiable computation schemes (see below).
+<!-- TODO: continue from this point -->
 
 For the remainder of this specification, this canonical representation is taken as implicit, and may be assumed where appropriate (e.g. `serialise` is called before sending a function over the network).
 

--- a/src/architecture/prerequisite-primitives.md
+++ b/src/architecture/prerequisite-primitives.md
@@ -2,19 +2,19 @@
 
 ## Canonical compute representation
 
-The protocol requires a [canonical serialisation](../glossary.md#canonical-serialization) of [Turing-equivalent](../glossary.md#turing-complete) functions and data.
+The protocol requires a [*canonical* serialisation](../glossary.md#canonical-serialization) of [Turing-equivalent](../glossary.md#turing-complete) functions and data.
 
-```haskell
-serialise :: a -> ByteString
-deserialise :: ByteString -> (Maybe a)
-```
+A *serialisation* can be any function which maps data to a series of bytes. The inverse function which maps a series of bytes to data is referred to as a *deserialisation*.
 
-<!-- 
-"by all agents using the protocol" 
+Being *canonical* for a serialisation $s$ means that there exists a function $d$
+such that, for any function or data $x$, all the agents using the protocol agree that
+
+$$s(\mathsf{eval}(d(x))) = x.$
 
 
+<!--  This is rather important I'd say.
+What if it's mention earlier.
  -->
-_Canonical_ here means that this serialisation must be agreed to by all agents using the protocol, such that those agents agree on the results of computing `serialise (eval (deserialise f))` for an arbitrary `f`. 
 
 Internal representations of compute may vary as long as this external equivalence holds. Certain additional correspondences of internal representations may be required for particular verifiable computation schemes (see below).
 

--- a/src/glossary.md
+++ b/src/glossary.md
@@ -1,0 +1,2 @@
+# Glossary
+

--- a/src/glossary.md
+++ b/src/glossary.md
@@ -1,2 +1,17 @@
 # Glossary
 
+# Anoma
+
+Anoma is ...
+
+# Agents
+
+An *agent* is ...
+Read more about agents in the [conceptual context](../architecture/conceptual-context.md).
+
+# World
+
+A *word* is a virtual environment which
+consists of a set of agents interacting with each other.
+
+Read more about the world in the [conceptual context](../architecture/conceptual-context.md).

--- a/src/glossary.md
+++ b/src/glossary.md
@@ -9,6 +9,10 @@ Anoma is ...
 An *agent* is ...
 Read more about agents in the [conceptual context](../architecture/conceptual-context.md).
 
+# Message
+
+A *message* is any data sent between agents.
+
 # World
 
 A *word* is a virtual environment which

--- a/src/glossary.md
+++ b/src/glossary.md
@@ -2,18 +2,30 @@
 
 # Anoma protocol
 
-The Anoma protocol (*the* protocol for short) is the logic framework which
-[agents](#agents) use to read, create, and process [messages](#message).
+The Anoma protocol is the logic framework which [agents](#agents) use to read,
+create, and process [messages](#message).
 
-# Agents
+# Agent
 
 An *agent* is a non-deterministic, stateful entity which can send and receive messages.
 
+The term "agent" is similar to "process" used in distributed systems. However, "agent" is used to highlight the possibility of non-deterministic behaviour, such as random events or choices made by external users. The term also emphasizes the idea of decision-making that can affect the state of the system. This is important for ensuring that the state of the system accurately reflects the state of the world. To achieve this, individual agents must provide data inputs that correspond in local ways, as the system protocol itself does not have direct knowledge of the state of the world.
+
+<!--
 The concept of _agent_ is similar to that of _process_ as used in the distributed systems literature. We use "agent" to emphasize non-determinism (local randomness and/or external user choice input) and possible agency (in the sense of decision-making which impacts the state of the system).
 
 The latter is especially important as *causal accounting* requires correspondence between the state of the system and state of the world, a correspondence which can only be maintained as a product of individual data inputs by agents which themselves correspond in local ways, as the protocol itself has no knowledge of the state of the world.
+-->
 
 Read more about agents in the [conceptual context](../architecture/conceptual-context.md).
+
+# Canonical serialization
+
+A "canonical serialization" refers to a standardized way of representing data or functions as a series of bytes that can be transmitted across a network. 
+
+# Turing-complete
+
+"Turing-equivalent" means that the functions and data being transmitted can be computed by a Turing machine, which is a theoretical model of a computer that can simulate any other computer algorithm.
 
 # Message
 

--- a/src/glossary.md
+++ b/src/glossary.md
@@ -26,7 +26,18 @@ consists of a set of agents interacting with each other.
 
 Read more about the world in the [conceptual context](../architecture/conceptual-context.md).
 
+
+# State
+
+A *state* may refer to the state of an agent, the state of the world, or the state of the system.
+
+- The *state of an agent* is the set of all data stored by the agent.
+
+- The *state of the world* is ... (not clear yet)
+
+- The *state of the system* is a function of the decisions taken by agents
+over (partially ordered) time.
+
 # System
 
 A *system* is ..
-

--- a/src/glossary.md
+++ b/src/glossary.md
@@ -1,12 +1,18 @@
 # Glossary
 
-# Anoma
+# Anoma protocol
 
-Anoma is ...
+The Anoma protocol (*the* protocol for short) is the logic framework which
+[agents](#agents) use to read, create, and process [messages](#message).
 
 # Agents
 
-An *agent* is ...
+An *agent* is a non-deterministic, stateful entity which can send and receive messages.
+
+The concept of _agent_ is similar to that of _process_ as used in the distributed systems literature. We use "agent" to emphasize non-determinism (local randomness and/or external user choice input) and possible agency (in the sense of decision-making which impacts the state of the system).
+
+The latter is especially important as *causal accounting* requires correspondence between the state of the system and state of the world, a correspondence which can only be maintained as a product of individual data inputs by agents which themselves correspond in local ways, as the protocol itself has no knowledge of the state of the world.
+
 Read more about agents in the [conceptual context](../architecture/conceptual-context.md).
 
 # Message
@@ -19,3 +25,8 @@ A *word* is a virtual environment which
 consists of a set of agents interacting with each other.
 
 Read more about the world in the [conceptual context](../architecture/conceptual-context.md).
+
+# System
+
+A *system* is ..
+

--- a/src/glossary.md
+++ b/src/glossary.md
@@ -7,9 +7,17 @@ create, and process [messages](#message).
 
 # Agent
 
-An *agent* is a non-deterministic, stateful entity which can send and receive messages.
+An *agent* is a non-deterministic, stateful entity which can send and receive
+messages.
 
-The term "agent" is similar to "process" used in distributed systems. However, "agent" is used to highlight the possibility of non-deterministic behaviour, such as random events or choices made by external users. The term also emphasizes the idea of decision-making that can affect the state of the system. This is important for ensuring that the state of the system accurately reflects the state of the world. To achieve this, individual agents must provide data inputs that correspond in local ways, as the system protocol itself does not have direct knowledge of the state of the world.
+The term "agent" is similar to "process" used in distributed systems. However,
+"agent" is used to highlight the possibility of non-deterministic behaviour,
+such as random events or choices made by external users. The term also
+emphasizes the idea of decision-making that can affect the state of the system.
+This is important for ensuring that the state of the system accurately reflects
+the state of the world. To achieve this, individual agents must provide data
+inputs that correspond in local ways, as the system protocol itself does not
+have direct knowledge of the state of the world.
 
 <!--
 The concept of _agent_ is similar to that of _process_ as used in the distributed systems literature. We use "agent" to emphasize non-determinism (local randomness and/or external user choice input) and possible agency (in the sense of decision-making which impacts the state of the system).
@@ -19,10 +27,13 @@ The latter is especially important as *causal accounting* requires correspondenc
 
 Read more about agents in the [conceptual context](../architecture/conceptual-context.md).
 
+
 # Canonical serialization
 
 A *canonical serialization* refers to a standardized way of representing data or
-functions as a series of bytes that can be transmitted across a network. 
+functions as a series of bytes that can be transmitted across a network.
+
+Cannonical serialization are fully discussed in [Prerequisites Primitives](../src/architecture/prerequisite-primitives.md).
 
 # Turing-equivalent
 
@@ -32,7 +43,6 @@ computed by a Turing machine, a well-known theoretical model of computation.
 # Message
 
 A *message* is any data sent between agents.
-
 
 # State
 
@@ -47,7 +57,6 @@ over (partially ordered) time.
 data related to the "real world" that is stored by the agents.
 
 # System
-
 
 A *system* is a virtual environment which
 consists of a set of agents interacting with each other.

--- a/src/glossary.md
+++ b/src/glossary.md
@@ -21,22 +21,17 @@ Read more about agents in the [conceptual context](../architecture/conceptual-co
 
 # Canonical serialization
 
-A "canonical serialization" refers to a standardized way of representing data or functions as a series of bytes that can be transmitted across a network. 
+A *canonical serialization* refers to a standardized way of representing data or
+functions as a series of bytes that can be transmitted across a network. 
 
-# Turing-complete
+# Turing-equivalent
 
-"Turing-equivalent" means that the functions and data being transmitted can be computed by a Turing machine, which is a theoretical model of a computer that can simulate any other computer algorithm.
+"Turing-equivalent" means that the functions and data being transmitted can be
+computed by a Turing machine, a well-known theoretical model of computation.
 
 # Message
 
 A *message* is any data sent between agents.
-
-# World
-
-A *word* is a virtual environment which
-consists of a set of agents interacting with each other.
-
-Read more about the world in the [conceptual context](../architecture/conceptual-context.md).
 
 
 # State
@@ -45,11 +40,16 @@ A *state* may refer to the state of an agent, the state of the world, or the sta
 
 - The *state of an agent* is the set of all data stored by the agent.
 
-- The *state of the world* is ... (not clear yet)
-
 - The *state of the system* is a function of the decisions taken by agents
 over (partially ordered) time.
 
+- The *state of the world* is the set of 
+data related to the "real world" that is stored by the agents.
+
 # System
 
-A *system* is ..
+
+A *system* is a virtual environment which
+consists of a set of agents interacting with each other.
+
+Read more about the world in the [conceptual context](../architecture/conceptual-context.md).


### PR DESCRIPTION
This PR reviews the topics discussed in 3.1 conceptual context: mostly Agents and systems. I also added a glossary (a starting point), which I think is helpful in the spec. Feel free to update this branch directly if you feel like it.